### PR TITLE
Adds support for FromUri named parameters

### DIFF
--- a/src/Drum.Tests/UriMakerTests.cs
+++ b/src/Drum.Tests/UriMakerTests.cs
@@ -36,6 +36,9 @@ namespace Drum.Tests
 
             [Route("{id}")]
             public void GetById(int id, bool detailed) { }
+
+            [Route("")]
+            public void GetPaged([FromUri(Name = "pager")]PageInfo page) { }
         }
         
         [Fact]
@@ -78,6 +81,13 @@ namespace Drum.Tests
         {
             var uri = _uriMaker.UriFor(c => c.GetPaged(new PageInfo{page = 2,count = 10}, true));
             Assert.Equal("http://example.org/api/UriMakerTests/resources?page=2&count=10&detailed=True", uri.ToString());
+        }
+
+        [Fact]
+        public void Can_make_uri_for_action_with_complex_named_uri_parameters()
+        {
+            var uri = _uriMaker.UriFor(c => c.GetPaged(new PageInfo { page = 5, count = 15 }));
+            Assert.Equal("http://example.org/api/UriMakerTests/resources?pager.page=5&pager.count=15", uri.ToString());
         }
         
         public UriMakerTests()

--- a/src/Drum/DecoratorRouteProvider.cs
+++ b/src/Drum/DecoratorRouteProvider.cs
@@ -100,11 +100,15 @@ namespace Drum
             }
             else
             {
+                var fromUriAttributes = parameterInfo.GetCustomAttributes(typeof(FromUriAttribute), false);
+                var fromUriAttribute = fromUriAttributes.FirstOrDefault() as FromUriAttribute;
+                var nameFormat = fromUriAttribute != null ? string.Format("{0}.{{0}}", fromUriAttribute.Name) : "{0}";
+
                 var type = parameterInfo.ParameterType;
                 var typeDesc = new AssociatedMetadataTypeTypeDescriptionProvider(type).GetTypeDescriptor(type);
                 var propDescs = typeDesc.GetProperties();
                 GetRouteValues = propDescs.OfType<PropertyDescriptor>()
-                    .Select(desc => new RouteValueHandler(desc.Name, desc.GetValue)).ToList();
+                    .Select(desc => new RouteValueHandler(string.Format(nameFormat, desc.Name), desc.GetValue)).ToList();
             }
 
             IsFromUri = true;


### PR DESCRIPTION
I added simple support for decorating complex objects with FromUri and assigning it a custom name so it would behave like a prefix. 

It is useful in cases where some actions takes multiple arguments of the same type. 
For example: 
```
SomeAction(int id, [FromUri(Name="firstPager")]Pager first, [FromUri(Name="secondPager")]Pager second)
```