### PR TITLE
Small usability improvements regarding instantiating a UriMaker.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 #---------------------------------#
 
 # version format
-version: 0.5.0-beta{build}
+version: 0.5.1-beta{build}
 
 #---------------------------------#
 #    environment configuration    #

--- a/src/Drum/HttpRequestExtensions.cs
+++ b/src/Drum/HttpRequestExtensions.cs
@@ -9,5 +9,10 @@ namespace Drum
             var context = req.GetConfiguration().TryGetUriMakerContext();
             return context != null ? context.NewUriMakerFor<T>(req) : null;
         }
+
+        public static UriMaker<TController> TryGetUriMaker<TController>(this TController controller, HttpRequestMessage req)
+        {
+            return req.TryGetUriMakerFor<TController>();
+        }
     }
 }

--- a/src/Drum/Properties/AssemblyInfo.cs
+++ b/src/Drum/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.5.0.0")]
+[assembly: AssemblyVersion("0.5.1.*")]
 [assembly: AssemblyInformationalVersion("0.5.0")]
-[assembly: AssemblyFileVersion("0.5.0.0")]
+[assembly: AssemblyFileVersion("0.5.1.0")]

--- a/src/Drum/Properties/AssemblyInfo.cs
+++ b/src/Drum/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.4.0.0")]
+[assembly: AssemblyVersion("0.4.1.0")]
 [assembly: AssemblyInformationalVersion("0.4.0")]
-[assembly: AssemblyFileVersion("0.4.0.0")]
+[assembly: AssemblyFileVersion("0.4.1.0")]

--- a/src/Drum/UriMaker.cs
+++ b/src/Drum/UriMaker.cs
@@ -50,24 +50,21 @@ namespace Drum
         }
     }
 
-    public class UriMaker<TController>
+    public class UriMaker<TController> : UriMaker
     {
-        private readonly UriMaker _uriMaker;
-
         public Uri UriFor(Expression<Action<TController>> action)
         {
-            return _uriMaker.UriFor(action);
+            return base.UriFor(action);
         }
 
         public Uri UriFor(Expression<Func<TController, object>> action)
         {
-            return _uriMaker.UriFor(action);
+            return base.UriFor(action);
         }
 
         public UriMaker(Func<MethodInfo, MethodHandler> mapper, UrlHelper urlHelper)
-        {
-            _uriMaker = new UriMaker(mapper, urlHelper);
-        }
+        : base(mapper, urlHelper)
+        {}
 
         public UriMaker(UriMakerContext fact, HttpRequestMessage req)
             : this(fact.RouteMap, new UrlHelper(req))


### PR DESCRIPTION
The main change here is to make `UriMaker<T>` inherit from `UriMaker`. This is mostly a "principle of least surprise" thing; in a lot of places the generic version is just calling through to the non-generic one, so it's clear that it is an extension and not a separate object. It also allows consuming code to specify a property of type `UriMaker` in a base controller class, and assign the generic version to it. 

Following on, the second change is to add an alternate form of the `TryGetUriMakerFor<T>()` method that can be used from outside the controller class. This allows a base class to have `this.TryGetUriMaker(Request);` and when called from a derived class, a `UriMaker<T>` of the correct type is returned.
